### PR TITLE
fix: --install subcommand sets .git/hooks/commit-msg as executable

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,14 @@ fn install() -> anyhow::Result<()> {
     }
     let mut file = File::create(path)?;
     file.write_all("#!/bin/bash\nmsglint \"$1\"\nexit\n".as_bytes())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = file.metadata()?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
--install subcommands properly sets `.git/hooks/commit-msg` file as executable on unix.

<img width="774" height="265" alt="Screenshot 2025-07-29 at 11 30 18 PM" src="https://github.com/user-attachments/assets/e111cfb8-5dc7-4029-913d-b8f25cb4062a" />

Closes #1